### PR TITLE
Github CI Release Binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,175 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  create-release:
+    name: create-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create artifacts directory
+        run: mkdir artifacts
+
+      - name: Get the release version from the tag
+        if: env.ARTIFACT_VERSION == ''
+        run: |
+          # Apparently, this is the right way to get a tag name. Really?
+          #
+          # See: https://github.community/t5/GitHub-Actions/How-to-get-just-the-tag-name/m-p/32167/highlight/true#M1027
+          echo "::set-env name=ARTIFACT_VERSION::${GITHUB_REF#refs/tags/}"
+          echo "version is: ${{ env.ARTIFACT_VERSION }}"
+      - name: Create GitHub release
+        id: release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.ARTIFACT_VERSION }}
+          release_name: ${{ env.ARTIFACT_VERSION }}
+
+      - name: Save release upload URL to artifact
+        run: echo "${{ steps.release.outputs.upload_url }}" > artifacts/release-upload-url
+
+      - name: Save version number to artifact
+        run: echo "${{ env.ARTIFACT_VERSION }}" > artifacts/release-version
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: artifacts
+          path: artifacts
+
+  build-release:
+    name: build-release
+    needs: ["create-release"]
+    runs-on: ${{ matrix.os }}
+    env:
+      CARGO: cargo
+      TARGET_FLAGS:
+      TARGET_DIR: ./target
+      RUST_BACKTRACE: 1
+      BIN_NAME: bast
+    strategy:
+      matrix:
+        #  build: [linux-musl, linux-gnu, macos, win-msvc, win-gnu, win32-msvc]
+        build: [linux-gnu, macos]
+        include:
+          # - build: linux-musl
+          #   os: ubuntu-18.04
+          #   rust: stable
+          #   target: x86_64-unknown-linux-musl
+          - build: linux-gnu
+            os: ubuntu-18.04
+            rust: stable
+            target: x86_64-unknown-linux-gnu
+          - build: macos
+            os: macos-latest
+            rust: stable
+            target: x86_64-apple-darwin
+          # - build: win-msvc
+          #   os: windows-2019
+          #   rust: nightly
+          #   target: x86_64-pc-windows-msvc
+          # - build: win-gnu
+          #   os: windows-2019
+          #   rust: nightly-x86_64-gnu
+          #   target: x86_64-pc-windows-gnu
+          # - build: win32-msvc
+          #   os: windows-2019
+          #   rust: nightly
+          #   target: i686-pc-windows-msvc
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+
+      - name: Install packages linux gnu
+        if: matrix.os == 'ubuntu-18.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends build-essential pkg-config libssl-dev
+
+      # - name: Install packages linux musl
+      #   if: matrix.os == 'ubuntu-18.04'
+      #   run: |
+      #     sudo apt-get update
+      #     sudo apt-get install -y --no-install-recommends xz-utils liblz4-tool pkg-config musl-tools libssl-dev
+
+      - name: Install packages linux macos
+        if: matrix.os == 'macos-latest'
+        run: |
+          echo "Only for future"
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          profile: minimal
+          override: true
+          target: ${{ matrix.target }}
+
+      - name: Setup Env Var
+        run: |
+          # cargo install --git https://github.com/rust-embedded/cross
+          echo "::set-env name=CARGO::cargo"
+          echo "::set-env name=TARGET_FLAGS::--target ${{ matrix.target }}"
+          echo "::set-env name=TARGET_DIR::./target/${{ matrix.target }}"
+
+      - name: Show command used for Cargo
+        run: |
+          echo "cargo command is: ${{ env.CARGO }}"
+          echo "target flag is: ${{ env.TARGET_FLAGS }}"
+          echo "target dir is: ${{ env.TARGET_DIR }}"
+
+      - name: Get release download URL
+        uses: actions/download-artifact@v1
+        with:
+          name: artifacts
+          path: artifacts
+
+      - name: Set release upload URL and release version
+        shell: bash
+        run: |
+          release_upload_url="$(cat artifacts/release-upload-url)"
+          echo "::set-env name=RELEASE_UPLOAD_URL::$release_upload_url"
+          echo "release upload url: $RELEASE_UPLOAD_URL"
+          release_version="$(cat artifacts/release-version)"
+          echo "::set-env name=RELEASE_VERSION::$release_version"
+          echo "release version: $RELEASE_VERSION"
+
+      - name: Build release binary
+        run: ${{ env.CARGO }} build --verbose --release ${{ env.TARGET_FLAGS }}
+
+      - name: Strip release binary (linux and macos)
+        if: matrix.build == 'linux-musl' || matrix.build == 'linux-gnu' || matrix.build == 'macos'
+        run: strip "target/${{ matrix.target }}/release/${{ env.BIN_NAME }}"
+
+      - name: Build archive
+        shell: bash
+        run: |
+          staging="${{ env.BIN_NAME }}-${{ env.RELEASE_VERSION }}-${{ matrix.target }}"
+          mkdir -p "$staging"
+          cp {README.md,LICENSE.md,.env.sample} "$staging/"
+          if [ "${{ matrix.os }}" = "windows-2019" ]; then
+            cp "target/${{ matrix.target }}/release/${{ env.BIN_NAME }}.exe" "$staging/"
+            7z a "$staging.zip" "$staging"
+            echo "::set-env name=ASSET::$staging.zip"
+          else
+            cp "target/${{ matrix.target }}/release/${{ env.BIN_NAME }}" "$staging/"
+            tar czf "$staging.tar.gz" "$staging"
+            echo "::set-env name=ASSET::$staging.tar.gz"
+          fi
+      - name: Upload release archive
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ env.RELEASE_UPLOAD_URL }}
+          asset_path: ${{ env.ASSET }}
+          asset_name: ${{ env.ASSET }}
+          asset_content_type: application/octet-stream

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,45 @@
+name: Rust
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run tests
+        run: cargo test --all
+      - name: fmt
+        run: cargo fmt --all -- --check
+      - name: clippy
+        run: cargo clippy
+      - name: Check crate package size (feat. 'cargo diet')
+        run: |
+          curl -LSfs https://raw.githubusercontent.com/the-lean-crate/cargo-diet/master/ci/install.sh | \
+           sh -s -- --git the-lean-crate/cargo-diet --target x86_64-unknown-linux-musl
+          cargo diet -n --package-size-limit 30KB
+  # Currently having issue with openssl
+  # build-and-test-on-windows:
+  #   name: Windows
+  #   runs-on: windows-latest
+  #   steps:
+  #     - uses: actions/checkout@v1
+  #     - uses: actions-rs/toolchain@v1
+  #       with:
+  #         profile: default
+  #         toolchain: nightly
+  #         override: true
+  #     - name: "Check (crossterm)"
+  #       uses: actions-rs/cargo@v1
+  #       with:
+  #         command: check
+  #         args: --all --bins --tests --examples
+  #     - name: "Test (crossterm)"
+  #       uses: actions-rs/cargo@v1
+  #       with:
+  #         command: test
+  #         args: --all


### PR DESCRIPTION
Here is the initial Github CI.

Currently it releases binary for Apple And Linux GNU

I did tried to setup for windows, windows32 and Linux MUSL (So we can statically compile without requiring glibc etc) but failed miserably due to openssl. And it already took me more than 6-7 hour to setup this ci so may be in future I can check how to support it.

Rust has a great support for rustles so can we use feature flag to compile it?

<3