### PR TITLE
Turn on LTO for release build.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,8 @@ woothee = "0.11.0"
 [[bin]]
 name = "bast"
 path = "server/main.rs"
+
+
+[profile.release]
+lto = "fat"
+codegen-units = 1


### PR DESCRIPTION
Use LTO to optimize the release build.

At the cost of compilation time but it is better for end user as server are supposed to accept more request and be as fast as possible in hotpaths.

And most of us use debug build for testing so shouldn't matter for release build if compilation time is little slow.